### PR TITLE
Add apparmor package before installing docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN wget -q -O - http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key | apt-key a
 RUN apt-get update
 RUN apt-get install -y jenkins
 RUN apt-get install -y git
+RUN apt-get install -y apparmor
 
 
 # now we install docker in docker - thanks to https://github.com/jpetazzo/dind


### PR DESCRIPTION
This was causing problems when i tried to set test jobs that ran docker commands. 
A sample job that ran bash script involving couple of docker commands just to see if my job can run docker commands, failed.
When I checked inside my container - the output of `docker -d` , it failed to launch daemon with error message saying: 
`apparmor_parser : no such file or directory`. 
so after doing `apt-get install apparmor` and re launching the daemon, jenkins job ran docker commands fine :)
if apparmor is installed during image build, this issue wont happen again :D cheers.
